### PR TITLE
Dont try to look for lambdas that have been deleted from the config files

### DIFF
--- a/lambda-version-manager.gemspec
+++ b/lambda-version-manager.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'lambda-version-manager'
-  s.version     = '0.0.17'
+  s.version     = '0.0.18'
   s.date        = '2019-02-19'
   s.summary     = "Lambda version manager"
   s.description = "Updates aws lambda versions to match a yaml property file"

--- a/lib/deployer.rb
+++ b/lib/deployer.rb
@@ -111,6 +111,7 @@ class Deployer
     historic = parse_archive
     historic.each do |environment, lambdas|
       lambdas.each do |lambda, configs|
+        next if new_project[environment][lambda].nil?
         if new_project[environment][lambda].has_key?('sha1')
           if configs.has_key?('sha1')  && (configs['sha1'] == new_project[environment][lambda]['sha1'])
             new_project[environment].delete(lambda)


### PR DESCRIPTION
When a lambda is removed, currently we get a failure on deploy because it is still present in the history and when we loop we were not accounting for a lambda having been removed from the config. With this change we should skip lambdas in the history that are not present in the current config. 